### PR TITLE
Support extending the highlight line on top

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/LineScatterCandleRadarDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/LineScatterCandleRadarDataSet.java
@@ -15,6 +15,9 @@ public abstract class LineScatterCandleRadarDataSet<T extends Entry> extends Bar
     protected boolean mDrawVerticalHighlightIndicator = true;
     protected boolean mDrawHorizontalHighlightIndicator = true;
 
+    /** the extra top height of the highlight indicator lines */
+    protected float mHighlightLineExtraTopHeight = 0f;
+
     /** the width of the highlight indicator lines */
     protected float mHighlightLineWidth = 0.5f;
 
@@ -60,6 +63,20 @@ public abstract class LineScatterCandleRadarDataSet<T extends Entry> extends Bar
     @Override
     public boolean isHorizontalHighlightIndicatorEnabled() {
         return mDrawHorizontalHighlightIndicator;
+    }
+
+    /**
+     * Sets extra height in dp to draw on top the highlight line.
+     * No effect if [BarLineChartBase.getClipDataToContent] is true.
+     *
+     * @param height
+     */
+    public void setHighlightLineExtraTopHeight(float height) {
+        mHighlightLineExtraTopHeight = Utils.convertDpToPixel(height);
+    }
+
+    public float getHighlightLineExtraTopHeight() {
+        return mHighlightLineExtraTopHeight;
     }
 
     /**

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/ILineScatterCandleRadarDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/ILineScatterCandleRadarDataSet.java
@@ -22,6 +22,12 @@ public interface ILineScatterCandleRadarDataSet<T extends Entry> extends IBarLin
     boolean isHorizontalHighlightIndicatorEnabled();
 
     /**
+     * Returns the extra top height to be added to highlight lines.
+     * @return
+     */
+    float getHighlightLineExtraTopHeight();
+
+    /**
      * Returns the line-width in which highlight lines are to be drawn.
      * @return
      */

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineScatterCandleRadarRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineScatterCandleRadarRenderer.java
@@ -43,7 +43,7 @@ public abstract class LineScatterCandleRadarRenderer extends BarLineScatterCandl
 
             // create vertical path
             mHighlightLinePath.reset();
-            mHighlightLinePath.moveTo(x, mViewPortHandler.contentTop());
+            mHighlightLinePath.moveTo(x, mViewPortHandler.contentTop() - set.getHighlightLineExtraTopHeight());
             mHighlightLinePath.lineTo(x, mViewPortHandler.contentBottom());
 
             c.drawPath(mHighlightLinePath, mHighlightPaint);


### PR DESCRIPTION
Allows the highlight line to be drawn all the way to the top of the view bounds, so we can have a separate tooltip view directly above it and it looks attached to the highlight line.